### PR TITLE
add if/else before return in parseLocation

### DIFF
--- a/genbank.js
+++ b/genbank.js
@@ -246,11 +246,20 @@ function parseLocation(location) {
 
         var startEndMatch = location.replace(/[<>]/g, '').match(/^([0-9]+)\.\.([0-9]+)$/);
 
-        return {
-            start: parseInt(startEndMatch[1]),
-            end: parseInt(startEndMatch[2]),
-            partial3Prime: partial3Prime,
-            partial5Prime: partial5Prime
+        if ( startEndMatch == null && location.match(/^([0-9]+)$/) ){
+            return {
+                start: parseInt(location),
+                end: parseInt(location),
+                partial3Prime: partial3Prime,
+                partial5Prime: partial5Prime
+            }
+        } else {
+            return {
+                start: parseInt(startEndMatch[1]),
+                end: parseInt(startEndMatch[2]),
+                partial3Prime: partial3Prime,
+                partial5Prime: partial5Prime
+            }
         }
     }
 }


### PR DESCRIPTION
Hi! I found this repo when searching for a js genbank parser. Thanks for making this available! I found an error when parsing a gb file that has features with the same start and stop location (in my case this file contained a 'misc_difference' feature). I enclosed the return statement in and if/else fork to avoid this error. What do you think? I hope you find this helpful! I certainly don't mean to be intrusive. This is very nice code!! Thanks again!  
